### PR TITLE
Feat: Ampliar dinámicamente los endpoints de la API de Alegra

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -12,29 +12,83 @@ const server = new McpServer({
 });
 logger.info("Iniciando Servidor MCP para Alegra...");
 server.tool("AlegraAPI", // Nombre de la herramienta
-"Una herramienta para interactuar con la API de contabilidad de Alegra. Permite consultar facturas, contactos y más.", // Descripción para la IA
+"Una herramienta para interactuar con la API de contabilidad de Alegra. Permite realizar operaciones CRUD en una amplia gama de recursos como Facturas, Contactos, Items, Notas de Crédito, Órdenes de Compra y muchos más.", // Descripción para la IA
 {
     // Esquema de argumentos usando Zod
-    endpoint: z.enum(['invoices', 'contacts', 'items']).describe("El tipo de recurso a consultar. Ej: 'invoices', 'contacts'."),
-    method: z.enum(['get', 'post']).default('get').describe("El método HTTP a utilizar."),
-    id: z.string().optional().describe("El ID específico de un recurso a consultar (ej: el ID de una factura)."),
-    queryParams: z.record(z.string()).optional().describe("Parámetros de consulta adicionales, como 'start', 'limit', 'query'.")
+    endpoint: z.enum([
+        'invoices',
+        'contacts',
+        'items',
+        'credit-notes',
+        'remissions',
+        'purchase-orders',
+        'estimates',
+        'income-debit-notes',
+        'global-invoices',
+        'transportation-receipts',
+        'recurring-invoices',
+        'payments',
+        'bills',
+        'debit-notes', // Este es para notas débito de proveedor
+        'recurring-payments',
+        'warehouses',
+        'warehouse-transfers',
+        'inventory-adjustments',
+        'price-lists',
+        'custom-fields',
+        'variant-attributes',
+        'item-categories',
+        'sellers',
+        'categories', // Para Cuentas Contables
+        'cost-centers',
+        'journals',
+        'bank-accounts',
+        'reconciliations',
+        'taxes',
+        'retentions',
+        'currencies',
+        'terms',
+        'company',
+        'users',
+        'number-templates',
+        'webhooks-subscriptions',
+        'additional-charges'
+    ]).describe("El tipo de recurso de la API de Alegra a consultar o modificar. Ej: 'invoices', 'contacts', 'items', 'credit-notes', 'purchase-orders', etc."),
+    method: z.enum(['get', 'post', 'put', 'delete']).default('get').describe("El método HTTP a utilizar (get, post, put, delete)."),
+    id: z.string().optional().describe("El ID específico de un recurso (ej: el ID de una factura para get, put, delete)."),
+    queryParams: z.record(z.string()).optional().describe("Parámetros de consulta adicionales (ej: 'start', 'limit', 'query' para GET) o cuerpo de la solicitud para POST/PUT.")
 }, async ({ endpoint, method, id, queryParams }) => {
     const BASE_URL = 'https://api.alegra.com/api/v1/';
     let url = `${BASE_URL}${endpoint}`;
     if (id) {
         url += `/${id}`;
     }
-    if (queryParams) {
-        const params = new URLSearchParams(queryParams);
-        url += `?${params.toString()}`;
+    // Definimos RequestInit aquí para poder modificarlo antes de fetch
+    const fetchOptions = {
+        method: method.toUpperCase(),
+        headers: getAlegraAuthHeaders() // Content-Type application/json ya está en getAlegraAuthHeaders
+    };
+    if (method.toUpperCase() === 'GET' || method.toUpperCase() === 'DELETE') {
+        if (queryParams && Object.keys(queryParams).length > 0) {
+            const params = new URLSearchParams(queryParams);
+            url += `?${params.toString()}`;
+        }
+    }
+    else if (method.toUpperCase() === 'POST' || method.toUpperCase() === 'PUT') {
+        if (queryParams && Object.keys(queryParams).length > 0) {
+            fetchOptions.body = JSON.stringify(queryParams);
+        }
+        else {
+            // Para POST/PUT, si no se proporcionan queryParams (cuerpo), enviar un cuerpo JSON vacío.
+            fetchOptions.body = JSON.stringify({});
+        }
     }
     logger.info(`Realizando petición: ${method.toUpperCase()} ${url}`);
+    if (fetchOptions.body) {
+        logger.info(`Con cuerpo: ${fetchOptions.body}`);
+    }
     try {
-        const response = await fetch(url, {
-            method: method.toUpperCase(),
-            headers: getAlegraAuthHeaders()
-        });
+        const response = await fetch(url, fetchOptions);
         if (!response.ok) {
             const errorBody = await response.text();
             throw new Error(`Error de la API de Alegra: ${response.status} ${response.statusText} - ${errorBody}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,20 @@
 {
-  "name": "alegra-mcp",
+  "name": "@juancsanchez/alegra-mcp",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "alegra-mcp",
+      "name": "@juancsanchez/alegra-mcp",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.1",
         "isomorphic-fetch": "^3.0.0",
         "zod": "^3.25.67"
+      },
+      "bin": {
+        "alegra-mcp": "build/main.js"
       },
       "devDependencies": {
         "@types/isomorphic-fetch": "^0.0.39",

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,13 +16,51 @@ logger.info("Iniciando Servidor MCP para Alegra...");
 
 server.tool(
   "AlegraAPI", // Nombre de la herramienta
-  "Una herramienta para interactuar con la API de contabilidad de Alegra. Permite consultar facturas, contactos y más.", // Descripción para la IA
+  "Una herramienta para interactuar con la API de contabilidad de Alegra. Permite realizar operaciones CRUD en una amplia gama de recursos como Facturas, Contactos, Items, Notas de Crédito, Órdenes de Compra y muchos más.", // Descripción para la IA
   {
     // Esquema de argumentos usando Zod
-    endpoint: z.enum(['invoices', 'contacts', 'items']).describe("El tipo de recurso a consultar. Ej: 'invoices', 'contacts'."),
-    method: z.enum(['get', 'post']).default('get').describe("El método HTTP a utilizar."),
-    id: z.string().optional().describe("El ID específico de un recurso a consultar (ej: el ID de una factura)."),
-    queryParams: z.record(z.string()).optional().describe("Parámetros de consulta adicionales, como 'start', 'limit', 'query'.")
+    endpoint: z.enum([
+        'invoices',
+        'contacts',
+        'items',
+        'credit-notes',
+        'remissions',
+        'purchase-orders',
+        'estimates',
+        'income-debit-notes',
+        'global-invoices',
+        'transportation-receipts',
+        'recurring-invoices',
+        'payments',
+        'bills',
+        'debit-notes', // Este es para notas débito de proveedor
+        'recurring-payments',
+        'warehouses',
+        'warehouse-transfers',
+        'inventory-adjustments',
+        'price-lists',
+        'custom-fields',
+        'variant-attributes',
+        'item-categories',
+        'sellers',
+        'categories', // Para Cuentas Contables
+        'cost-centers',
+        'journals',
+        'bank-accounts',
+        'reconciliations',
+        'taxes',
+        'retentions',
+        'currencies',
+        'terms',
+        'company',
+        'users',
+        'number-templates',
+        'webhooks-subscriptions',
+        'additional-charges'
+    ]).describe("El tipo de recurso de la API de Alegra a consultar o modificar. Ej: 'invoices', 'contacts', 'items', 'credit-notes', 'purchase-orders', etc."),
+    method: z.enum(['get', 'post', 'put', 'delete']).default('get').describe("El método HTTP a utilizar (get, post, put, delete)."),
+    id: z.string().optional().describe("El ID específico de un recurso (ej: el ID de una factura para get, put, delete)."),
+    queryParams: z.record(z.string()).optional().describe("Parámetros de consulta adicionales (ej: 'start', 'limit', 'query' para GET) o cuerpo de la solicitud para POST/PUT.")
   },
   
   async ({ endpoint, method, id, queryParams }) => {
@@ -33,18 +71,33 @@ server.tool(
         url += `/${id}`;
     }
 
-    if (queryParams) {
-        const params = new URLSearchParams(queryParams);
-        url += `?${params.toString()}`;
+    // Definimos RequestInit aquí para poder modificarlo antes de fetch
+    const fetchOptions: RequestInit = {
+        method: method.toUpperCase(),
+        headers: getAlegraAuthHeaders() // Content-Type application/json ya está en getAlegraAuthHeaders
+    };
+
+    if (method.toUpperCase() === 'GET' || method.toUpperCase() === 'DELETE') {
+        if (queryParams && Object.keys(queryParams).length > 0) {
+            const params = new URLSearchParams(queryParams);
+            url += `?${params.toString()}`;
+        }
+    } else if (method.toUpperCase() === 'POST' || method.toUpperCase() === 'PUT') {
+        if (queryParams && Object.keys(queryParams).length > 0) {
+            fetchOptions.body = JSON.stringify(queryParams);
+        } else {
+            // Para POST/PUT, si no se proporcionan queryParams (cuerpo), enviar un cuerpo JSON vacío.
+            fetchOptions.body = JSON.stringify({});
+        }
     }
 
     logger.info(`Realizando petición: ${method.toUpperCase()} ${url}`);
+    if (fetchOptions.body) {
+        logger.info(`Con cuerpo: ${fetchOptions.body}`);
+    }
 
     try {
-        const response = await fetch(url, {
-        method: method.toUpperCase(),
-        headers: getAlegraAuthHeaders()
-        });
+        const response = await fetch(url, fetchOptions);
 
         if (!response.ok) {
         const errorBody = await response.text();


### PR DESCRIPTION
Se modifica la herramienta principal de AlegraAPI para incluir una lista exhaustiva de los servicios (endpoints) disponibles en la API de Alegra, permitiendo una interacción más completa.

Cambios realizados:
- Se actualiza el enum de `endpoint` en el esquema Zod de `src/main.ts` para incluir recursos como Notas de Crédito, Remisiones, Órdenes de Compra, y muchos más, basados en la documentación oficial.
- Se expande el enum de `method` para soportar 'PUT' y 'DELETE', además de 'GET' y 'POST'.
- Se ajusta la lógica de manejo de `queryParams` para que sirva como parámetros de URL para GET/DELETE y como cuerpo de solicitud JSON para POST/PUT. Se envía un cuerpo `{}` por defecto para POST/PUT si no se especifican datos.
- Se actualiza la descripción de la herramienta para reflejar su capacidad ampliada.
- Se confirma que la lógica de autenticación no requiere cambios y sigue siendo aplicable.
- Se ejecuta `npm install` y `npm run build` para asegurar que el proyecto se construya correctamente.