### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Este proyecto implementa un servidor compatible con el Protocolo de Contexto de 
 
 Elaborado por Juan Sánchez.
 
+<a href="https://glama.ai/mcp/servers/@juancsanchez/Alegra-MCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@juancsanchez/Alegra-MCP/badge" alt="Alegra Server MCP server" />
+</a>
+
 ## Características
 
   * **Integración con Alegra**: Ofrece una herramienta (`AlegraAPI`) para realizar consultas a los *endpoints* de la API de Alegra.


### PR DESCRIPTION
This PR adds a badge for the [Alegra MCP Server](https://glama.ai/mcp/servers/@juancsanchez/Alegra-MCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@juancsanchez/Alegra-MCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@juancsanchez/Alegra-MCP/badge" alt="Alegra Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.